### PR TITLE
update brew cask install commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ brew install git
 brew install node
 brew install yarn
 brew install watchman
-brew cask install android-platform-tools
-brew cask install android-sdk
-brew cask install android-studio
+brew install --cask android-platform-tools
+brew install --cask android-sdk
+brew install --cask android-studio
 ```
 
 (Only Xcode is missing with the commands above)


### PR DESCRIPTION
brew recently disabled `brew cask install` and switch to `brew install --cask`. 

This PR updates the readme to use the new command.

You can see others talking about the change here: https://github.com/ansible-collections/community.general/issues/1524